### PR TITLE
Fix breakage with make -n

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,8 +50,9 @@ build:; @cd src; $(MAKE) all \
 
 clean:; cd src; $(MAKE) clean
 
-distclean:;     rm Makefile config.cache config.log config.status; \
-                cd src; $(MAKE) clean
+distclean:
+	rm -f Makefile config.cache config.log config.status
+	cd src && $(MAKE) clean
 
 test:           build
 		cd testing; ./runtest


### PR DESCRIPTION
With $(MAKE) in a recipe GNU make treats "-n" a noop, i.e. the recipe is executed when testing e.g. for the target existence.